### PR TITLE
Add dashboard charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ Analysiere den {{datentyp}} für {{unternehmen}}:
 
 ### Dashboard
 - Übersichtliche Statistik zu allen gespeicherten Prompts
-- Zeigt die Anzahl der Prompts pro Kategorie
+- Balkendiagramm mit Anzahl der Prompts pro Kategorie
+- Kreisdiagramm zeigt die Verteilung der Tags
 - Über einen Button in der Kopfzeile erreichbar
 
 ## 💡 Tipps & Tricks

--- a/dashboard.html
+++ b/dashboard.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dashboard - LLM Prompt Manager Pro</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
     <div class="app-container">
@@ -13,6 +14,8 @@
         </header>
         <main>
             <div id="metrics"></div>
+            <canvas id="categoryChart" height="200"></canvas>
+            <canvas id="tagChart" height="200"></canvas>
             <p><a href="index.html">Zurück zur Hauptansicht</a></p>
         </main>
     </div>

--- a/dashboard.js
+++ b/dashboard.js
@@ -2,28 +2,67 @@ document.addEventListener('DOMContentLoaded', () => {
     const prompts = JSON.parse(localStorage.getItem('prompts')) || [];
     const categories = JSON.parse(localStorage.getItem('categories')) || [];
 
-    const counts = {};
+    const categoryCounts = {};
     categories.forEach(cat => {
-        counts[cat.id] = 0;
+        categoryCounts[cat.name] = 0;
     });
 
+    const tagCounts = {};
+
     prompts.forEach(prompt => {
-        if (counts[prompt.category] !== undefined) {
-            counts[prompt.category]++;
-        } else {
-            counts[prompt.category] = 1;
-        }
+        const cat = categories.find(c => c.id === prompt.category);
+        const name = cat ? cat.name : prompt.category;
+        categoryCounts[name] = (categoryCounts[name] || 0) + 1;
+
+        (prompt.tags || []).forEach(tag => {
+            tagCounts[tag] = (tagCounts[tag] || 0) + 1;
+        });
     });
 
     const metrics = document.getElementById('metrics');
     const total = prompts.length;
     let html = `<p><strong>Gesamtanzahl Prompts:</strong> ${total}</p>`;
     html += '<ul>';
-    Object.keys(counts).forEach(id => {
-        const category = categories.find(c => c.id === id);
-        const name = category ? category.name : id;
-        html += `<li>${name}: ${counts[id]}</li>`;
+    Object.keys(categoryCounts).forEach(name => {
+        html += `<li>${name}: ${categoryCounts[name]}</li>`;
     });
     html += '</ul>';
     metrics.innerHTML = html;
+
+    // Chart: Prompts per category
+    const categoryCtx = document.getElementById('categoryChart').getContext('2d');
+    new Chart(categoryCtx, {
+        type: 'bar',
+        data: {
+            labels: Object.keys(categoryCounts),
+            datasets: [{
+                label: 'Prompts pro Kategorie',
+                data: Object.values(categoryCounts),
+                backgroundColor: 'rgba(0, 122, 255, 0.5)'
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: { display: false }
+            }
+        }
+    });
+
+    // Chart: Tag distribution
+    const tagCtx = document.getElementById('tagChart').getContext('2d');
+    new Chart(tagCtx, {
+        type: 'pie',
+        data: {
+            labels: Object.keys(tagCounts),
+            datasets: [{
+                label: 'Tag Verteilung',
+                data: Object.values(tagCounts),
+                backgroundColor: Object.keys(tagCounts).map((_, i) => `hsl(${i * 50},70%,70%)`)
+            }]
+        },
+        options: {
+            responsive: true
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- add Chart.js to the dashboard
- show charts for prompts per category and tag distribution
- document new dashboard functionality

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684da2e94fc8832eb952e53b8f4ca899