### PR TITLE
Fix prompt modal scrolling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -504,6 +504,11 @@ dialog::backdrop {
   position: relative;
 }
 
+.modal-overlay .modal-content pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .close-modal {
   position: absolute;
   top: 15px;


### PR DESCRIPTION
## Summary
- ensure the prompt modal uses wrapped text so long lines scroll vertically

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ee4837604832e9526064c3712e2a2