### PR TITLE
Add Markdown export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ open index.html
 ### 🔧 Funktionale Verbesserungen
 - **Bessere Performance**: Optimierte Rendering-Performance
 - **Stabilere Kategorien**: Robuste Kategorie-Filter-Funktionalität
-- **Import/Export**: Verbesserte Datenportabilität
+- **Import/Export**: Verbesserte Datenportabilität inklusive Markdown-Export
 - **Responsive Design**: Optimiert für verschiedene Bildschirmgrößen
 
 ## 🛠️ Kategorien verwalten
@@ -101,8 +101,8 @@ Analysiere den {{datentyp}} für {{unternehmen}}:
 
 ### Daten exportieren
 1. **Menü-Button** (⚙️) klicken
-2. **"📤 Export"** wählen
-3. **JSON-Datei** wird heruntergeladen mit:
+2. **"📤 Export"** wählen für eine JSON-Datei oder **"📄 Markdown"** für eine Markdown-Datei
+3. **Datei** wird heruntergeladen mit:
    - Alle Prompts
    - Alle Kategorien
    - Metadaten (Exportdatum, Version)
@@ -165,7 +165,7 @@ Analysiere den {{datentyp}} für {{unternehmen}}:
 ### Datenspeicherung
 - **LocalStorage**: Alle Daten bleiben auf deinem Computer
 - **Keine Cloud**: Kein Datentransfer an externe Server
-- **JSON-Format**: Standard-Format für Import/Export
+- **JSON-Format**: Standard-Format für Import/Export (optional Markdown)
 - **Versionierung**: Kompatibilität mit zukünftigen Updates
 
 ### Progressive Web App (PWA)

--- a/app.js
+++ b/app.js
@@ -69,6 +69,7 @@ class PromptManager {
 
         // Import/Export
         document.getElementById('exportBtn').addEventListener('click', () => this.exportData());
+        document.getElementById('exportMdBtn').addEventListener('click', () => this.exportMarkdown());
         document.getElementById('importBtn').addEventListener('click', () => document.getElementById('importFile').click());
         document.getElementById('importFile').addEventListener('change', (e) => this.importData(e));
 
@@ -418,6 +419,42 @@ class PromptManager {
         URL.revokeObjectURL(url);
 
         this.showToast('Daten exportiert!');
+    }
+
+    exportMarkdown() {
+        const lines = [];
+        lines.push('# Prompt Manager Export');
+        lines.push(`Exportdatum: ${new Date().toLocaleDateString('de-DE')}`);
+        lines.push('');
+
+        this.prompts.forEach(prompt => {
+            const categoryPath = categoryManager.getCategoryPath(prompt.category);
+            lines.push(`## ${prompt.title}`);
+            if (prompt.shortDescription) {
+                lines.push(prompt.shortDescription);
+                lines.push('');
+            }
+            lines.push(`- **Kategorie:** ${categoryPath}`);
+            lines.push(`- **Erstellt:** ${new Date(prompt.created).toLocaleDateString('de-DE')}`);
+            if (prompt.tags && prompt.tags.length) {
+                lines.push(`- **Tags:** ${prompt.tags.join(', ')}`);
+            }
+            lines.push('');
+            lines.push('```');
+            lines.push(prompt.content);
+            lines.push('```');
+            lines.push('');
+        });
+
+        const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `prompt-manager-export-${new Date().toISOString().split('T')[0]}.md`;
+        a.click();
+        URL.revokeObjectURL(url);
+
+        this.showToast('Markdown exportiert!');
     }
 
     importData(event) {

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
                     <div class="dropdown-content">
                         <button id="newPromptBtn">+ Neuer Prompt</button>
                         <button id="exportBtn">📤 Export</button>
+                        <button id="exportMdBtn">📄 Markdown</button>
                         <button id="importBtn">📥 Import</button>
                         <input type="file" id="importFile" accept=".json" style="display: none;">
                     </div>


### PR DESCRIPTION
## Summary
- add a Markdown export button to the menu
- support exporting prompts as `prompt-manager-export-<date>.md`
- document Markdown export in the README

## Testing
- `bash start-app.sh <<'EOF'
1
EOF` *(fails: open: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503f2bfbec832e96ae592116156d42