### PR TITLE
Add Neumorphic dashboard and favorite prompts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,10 @@
 class PromptManager {
     constructor() {
         this.prompts = JSON.parse(localStorage.getItem('prompts')) || this.getDefaultPrompts();
+        this.prompts.forEach(p => {
+            if (p.favorite === undefined) p.favorite = false;
+            if (p.usageCount === undefined) p.usageCount = 0;
+        });
         this.currentView = 'grid';
         this.editingPromptId = null;
 
@@ -22,7 +26,9 @@ class PromptManager {
                 category: "coding",
                 tags: ["code-review", "quality", "best-practices"],
                 created: new Date().toISOString(),
-                updated: new Date().toISOString()
+                updated: new Date().toISOString(),
+                favorite: false,
+                usageCount: 0
             },
             {
                 id: 2,
@@ -33,7 +39,9 @@ class PromptManager {
                 category: "content",
                 tags: ["blog", "seo", "content-marketing"],
                 created: new Date().toISOString(),
-                updated: new Date().toISOString()
+                updated: new Date().toISOString(),
+                favorite: false,
+                usageCount: 0
             },
             {
                 id: 3,
@@ -44,7 +52,9 @@ class PromptManager {
                 category: "analysis",
                 tags: ["data", "statistics", "insights"],
                 created: new Date().toISOString(),
-                updated: new Date().toISOString()
+                updated: new Date().toISOString(),
+                favorite: false,
+                usageCount: 0
             },
             {
                 id: 4,
@@ -55,7 +65,9 @@ class PromptManager {
                 category: "support",
                 tags: ["email", "communication", "professional"],
                 created: new Date().toISOString(),
-                updated: new Date().toISOString()
+                updated: new Date().toISOString(),
+                favorite: false,
+                usageCount: 0
             }
         ];
     }
@@ -145,7 +157,9 @@ class PromptManager {
             ...data,
             id: Date.now(),
             created: new Date().toISOString(),
-            updated: new Date().toISOString()
+            updated: new Date().toISOString(),
+            favorite: false,
+            usageCount: 0
         };
 
         this.prompts.push(newPrompt);
@@ -177,9 +191,21 @@ class PromptManager {
         }
     }
 
+    toggleFavorite(id) {
+        const prompt = this.prompts.find(p => p.id === id);
+        if (prompt) {
+            prompt.favorite = !prompt.favorite;
+            this.savePrompts();
+            this.renderPrompts();
+        }
+    }
+
     executeTemplate(id) {
         const prompt = this.prompts.find(p => p.id === id);
         if (!prompt) return;
+
+        prompt.usageCount = (prompt.usageCount || 0) + 1;
+        this.savePrompts();
 
         const variables = this.extractTemplateVariables(prompt.content);
         if (variables.length === 0) {
@@ -251,6 +277,7 @@ class PromptManager {
             <div class="prompt-card" style="border-top-color: ${categoryColor};">
                 <div class="prompt-card-header">
                     <h3 ondblclick="promptManager.showFullDescription(${prompt.id})">${prompt.title}</h3>
+                    <button class="favorite-btn ${prompt.favorite ? '' : 'inactive'}" onclick="promptManager.toggleFavorite(${prompt.id})">${prompt.favorite ? '⭐' : '☆'}</button>
                 </div>
                 <div class="prompt-card-body">
                     <div class="prompt-meta">
@@ -277,7 +304,7 @@ class PromptManager {
 
         return `
             <tr>
-                <td><strong>${prompt.title}</strong></td>
+                <td><button class="favorite-btn ${prompt.favorite ? '' : 'inactive'}" onclick="promptManager.toggleFavorite(${prompt.id})">${prompt.favorite ? '⭐' : '☆'}</button> <strong>${prompt.title}</strong></td>
                 <td>${prompt.shortDescription || 'Keine Kurzbeschreibung'}</td>
                 <td>${categoryPath}</td>
                 <td>${prompt.tags.join(', ')}</td>
@@ -481,6 +508,11 @@ class PromptManager {
                             this.prompts.push(prompt);
                         });
                     }
+
+                    this.prompts.forEach(p => {
+                        if (p.favorite === undefined) p.favorite = false;
+                        if (p.usageCount === undefined) p.usageCount = 0;
+                    });
 
                     this.savePrompts();
                     categoryManager.saveCategories();

--- a/dashboard.html
+++ b/dashboard.html
@@ -13,6 +13,9 @@
             <h1>📊 Dashboard</h1>
         </header>
         <main>
+            <section id="categoryOverview"></section>
+            <section id="topPrompts"></section>
+            <section id="favoritePrompts"></section>
             <div id="metrics"></div>
             <canvas id="categoryChart" height="200"></canvas>
             <canvas id="tagChart" height="200"></canvas>

--- a/dashboard.js
+++ b/dashboard.js
@@ -19,15 +19,28 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    document.getElementById('categoryOverview').innerHTML = `
+        <h2>Kategorien</h2>
+        <ul>${Object.keys(categoryCounts).map(name => `<li>${name}: ${categoryCounts[name]}</li>`).join('')}</ul>
+    `;
+
+    const topPrompts = prompts
+        .sort((a, b) => (b.usageCount || 0) - (a.usageCount || 0))
+        .slice(0, 5);
+    document.getElementById('topPrompts').innerHTML = `
+        <h2>Meistgenutzte Prompts</h2>
+        <ul>${topPrompts.map(p => `<li>${p.title} (${p.usageCount || 0}×)</li>`).join('')}</ul>
+    `;
+
+    const favoritePrompts = prompts.filter(p => p.favorite).slice(0, 10);
+    document.getElementById('favoritePrompts').innerHTML = `
+        <h2>Favoriten</h2>
+        <ul>${favoritePrompts.map(p => `<li>${p.title}</li>`).join('')}</ul>
+    `;
+
     const metrics = document.getElementById('metrics');
     const total = prompts.length;
-    let html = `<p><strong>Gesamtanzahl Prompts:</strong> ${total}</p>`;
-    html += '<ul>';
-    Object.keys(categoryCounts).forEach(name => {
-        html += `<li>${name}: ${categoryCounts[name]}</li>`;
-    });
-    html += '</ul>';
-    metrics.innerHTML = html;
+    metrics.innerHTML = `<p><strong>Gesamtanzahl Prompts:</strong> ${total}</p>`;
 
     // Chart: Prompts per category
     const categoryCtx = document.getElementById('categoryChart').getContext('2d');

--- a/styles.css
+++ b/styles.css
@@ -5,13 +5,13 @@
   --success-color: #34c759;
   --warning-color: #ff9500;
   --danger-color: #ff3b30;
-  --background-color: #f2f2f7;
-  --card-bg: #ffffff;
-  --border-color: #d1d1d6;
+  --background-color: #e0e5ec;
+  --card-bg: #e0e5ec;
+  --border-color: #d1d9e6;
   --text-primary: #1c1c1e;
   --text-secondary: #3a3a3c;
-  --shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-  --shadow-lg: 0 8px 20px rgba(0, 0, 0, 0.12);
+  --shadow: 8px 8px 16px #b8c6db, -8px -8px 16px #ffffff;
+  --shadow-lg: 12px 12px 24px #b8c6db, -12px -12px 24px #ffffff;
   --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
@@ -22,13 +22,13 @@ body.dark-theme {
   --success-color: #30d158;
   --warning-color: #ffd60a;
   --danger-color: #ff453a;
-  --background-color: #1c1c1e;
-  --card-bg: #2c2c2e;
-  --border-color: #3a3a3c;
+  --background-color: #2e3239;
+  --card-bg: #2e3239;
+  --border-color: #1c1f26;
   --text-primary: #f2f2f7;
   --text-secondary: #d1d1d6;
-  --shadow: 0 4px 12px rgba(0, 0, 0, 0.6);
-  --shadow-lg: 0 8px 20px rgba(0, 0, 0, 0.8);
+  --shadow: 8px 8px 16px #1c1f26, -8px -8px 16px #363b42;
+  --shadow-lg: 12px 12px 24px #1c1f26, -12px -12px 24px #363b42;
 }
 
 * {
@@ -56,11 +56,9 @@ body {
   align-items: center;
   margin-bottom: 30px;
   padding: 20px 30px;
-  background: rgba(255, 255, 255, 0.8);
-  backdrop-filter: saturate(180%) blur(20px);
+  background: var(--card-bg);
   border-radius: 12px;
   box-shadow: var(--shadow);
-  border: 1px solid var(--border-color);
 }
 
 .app-header h1 {
@@ -79,19 +77,18 @@ body {
 button {
   padding: 10px 16px;
   border: none;
-  border-radius: 8px;
-  background: linear-gradient(180deg, var(--primary-color) 0%, var(--secondary-color) 100%);
-  color: #fff;
+  border-radius: 10px;
+  background: var(--card-bg);
+  color: var(--text-primary);
   cursor: pointer;
   font-size: 14px;
   font-weight: 500;
-  transition: all 0.2s ease;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  transition: box-shadow 0.2s ease;
+  box-shadow: var(--shadow);
 }
 
 button:hover {
-  filter: brightness(1.05);
-  transform: translateY(-1px);
+  box-shadow: var(--shadow-lg);
 }
 
 /* Dropdown */
@@ -254,6 +251,9 @@ button:hover {
   padding: 16px;
   background: var(--card-bg);
   color: var(--text-primary);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .prompt-card-header h3 {
@@ -314,6 +314,18 @@ button:hover {
   background: var(--text-secondary);
 }
 
+.favorite-btn {
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: var(--warning-color);
+}
+
+.favorite-btn.inactive {
+  color: var(--border-color);
+}
+
 .btn-execute {
   background: var(--success-color);
 }
@@ -361,6 +373,16 @@ button:hover {
 
 .prompt-table td button:last-child {
   margin-right: 0;
+}
+
+#categoryOverview,
+#topPrompts,
+#favoritePrompts {
+  margin-bottom: 30px;
+  padding: 20px;
+  background: var(--card-bg);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
 }
 
 .prompt-table tr:nth-child(even) {


### PR DESCRIPTION
## Summary
- restyle with neumorphic minimalism
- add favorite star buttons and usage count tracking
- show top prompts and favorites on the dashboard
- provide category overview section in dashboard

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685132c2cec8832e91b022e2cafde3ed