### PR TITLE
Designupdate für Favoritenstern und Eingabefelder

### DIFF
--- a/app.js
+++ b/app.js
@@ -277,7 +277,7 @@ class PromptManager {
             <div class="prompt-card" style="border-top-color: ${categoryColor};">
                 <div class="prompt-card-header">
                     <h3 ondblclick="promptManager.showFullDescription(${prompt.id})">${prompt.title}</h3>
-                    <button class="favorite-btn ${prompt.favorite ? '' : 'inactive'}" onclick="promptManager.toggleFavorite(${prompt.id})">${prompt.favorite ? '⭐' : '☆'}</button>
+                    <button class="favorite-btn ${prompt.favorite ? 'active' : 'inactive'}" onclick="promptManager.toggleFavorite(${prompt.id})">☆</button>
                 </div>
                 <div class="prompt-card-body">
                     <div class="prompt-meta">
@@ -304,7 +304,7 @@ class PromptManager {
 
         return `
             <tr>
-                <td><button class="favorite-btn ${prompt.favorite ? '' : 'inactive'}" onclick="promptManager.toggleFavorite(${prompt.id})">${prompt.favorite ? '⭐' : '☆'}</button> <strong>${prompt.title}</strong></td>
+                <td><button class="favorite-btn ${prompt.favorite ? 'active' : 'inactive'}" onclick="promptManager.toggleFavorite(${prompt.id})">☆</button> <strong>${prompt.title}</strong></td>
                 <td>${prompt.shortDescription || 'Keine Kurzbeschreibung'}</td>
                 <td>${categoryPath}</td>
                 <td>${prompt.tags.join(', ')}</td>

--- a/styles.css
+++ b/styles.css
@@ -311,19 +311,31 @@ button:hover {
   flex: 1;
   padding: 6px 10px;
   font-size: 12px;
-  background: var(--text-secondary);
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  box-shadow: none;
+}
+
+.prompt-actions button:hover {
+  background: var(--background-color);
 }
 
 .favorite-btn {
   background: none;
-  border: none;
-  font-size: 20px;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
+  box-shadow: none;
+  font-size: 18px;
   cursor: pointer;
+  color: var(--text-secondary);
+}
+
+.favorite-btn.active {
   color: var(--warning-color);
 }
 
 .favorite-btn.inactive {
-  color: var(--border-color);
+  color: var(--text-secondary);
 }
 
 .btn-execute {
@@ -432,9 +444,10 @@ dialog::backdrop {
 .form-group select {
   width: 100%;
   padding: 12px;
-  border: 2px solid var(--border-color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
   font-size: 14px;
+  box-shadow: none;
 }
 
 .form-group textarea {


### PR DESCRIPTION
## Summary
- reduziere visuelle Dominanz des Favoritensterns
- passe Buttons in der Kartenansicht an das restliche Design an
- entferne Schatten und starke Ränder an Formularfeldern

## Testing
- `bash start-app.sh <<'EOF'
6
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68513c11095c832e8ca58a3e88a2e317