### PR TITLE
UI improvements for dark theme

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ class PromptManager {
             if (p.usageCount === undefined) p.usageCount = 0;
         });
         this.currentView = 'grid';
+        this.showFavoritesOnly = false;
         this.editingPromptId = null;
 
         this.applySavedTheme();
@@ -77,6 +78,7 @@ class PromptManager {
         document.getElementById('categoriesBtn').addEventListener('click', () => this.showCategoryDialog());
         document.getElementById('toggleViewBtn').addEventListener('click', () => this.toggleView());
         document.getElementById('newPromptBtn').addEventListener('click', () => this.showPromptDialog());
+        document.getElementById('favoritesBtn').addEventListener('click', () => this.toggleFavoritesFilter());
         document.getElementById('themeToggle').addEventListener('click', () => this.toggleTheme());
 
         // Import/Export
@@ -343,6 +345,18 @@ class PromptManager {
 
     showCategoryDialog() {
         categoryManager.showCategoryDialog();
+    }
+
+    toggleFavoritesFilter() {
+        const btn = document.getElementById('favoritesBtn');
+        this.showFavoritesOnly = !this.showFavoritesOnly;
+        if (this.showFavoritesOnly) {
+            btn.textContent = '★ Alle';
+            this.displayPrompts(this.prompts.filter(p => p.favorite));
+        } else {
+            btn.textContent = '☆ Favoriten';
+            this.displayPrompts(this.prompts);
+        }
     }
 
     toggleView() {

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
                 <button id="categoriesBtn">📁 Kategorien</button>
                 <button id="toggleViewBtn">📊 Tabellenansicht</button>
                 <button id="dashboardBtn" onclick="window.location.href='dashboard.html'">📈 Dashboard</button>
+                <button id="favoritesBtn">☆ Favoriten</button>
                 <button id="themeToggle">🌙 Dunkles Theme</button>
                 <div class="dropdown">
                     <button id="menuBtn">⚙️ Menü</button>
@@ -26,6 +27,7 @@
                         <button id="exportBtn">📤 Export</button>
                         <button id="exportMdBtn">📄 Markdown</button>
                         <button id="importBtn">📥 Import</button>
+                        <button id="categoriesMenuItem" onclick="promptManager.showCategoryDialog()">📁 Kategorien</button>
                         <input type="file" id="importFile" accept=".json" style="display: none;">
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,10 @@ button {
   box-shadow: var(--shadow);
 }
 
+button:focus {
+  outline: none;
+}
+
 button:hover {
   box-shadow: var(--shadow-lg);
 }
@@ -139,6 +143,7 @@ button:hover {
   border: 2px solid var(--border-color);
   border-radius: 8px;
   background: var(--card-bg);
+  color: var(--text-primary);
 }
 
 /* Main Layout */
@@ -296,6 +301,11 @@ button:hover {
   font-weight: 500;
 }
 
+body.dark-theme .tag {
+  background: #444;
+  color: var(--text-primary);
+}
+
 .prompt-actions {
   display: flex;
   gap: 8px;
@@ -448,6 +458,8 @@ dialog::backdrop {
   border-radius: 8px;
   font-size: 14px;
   box-shadow: none;
+  background: var(--card-bg);
+  color: var(--text-primary);
 }
 
 .form-group textarea {
@@ -594,4 +606,17 @@ dialog::backdrop {
   .prompt-grid {
     grid-template-columns: 1fr;
   }
+}
+
+@media (max-width: 600px) {
+  #categoriesBtn {
+    display: none;
+  }
+  #categoriesMenuItem {
+    display: block;
+  }
+}
+
+#categoriesMenuItem {
+  display: none;
 }


### PR DESCRIPTION
## Summary
- adjust tag background color for dark mode
- hide default focus outline on buttons
- colorize select elements correctly
- add favorites filter button and responsive category menu

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68517eb437c8832e98264d4c649d0c0f