### PR TITLE
Improve Neumorphic style

### DIFF
--- a/app.js
+++ b/app.js
@@ -257,6 +257,12 @@ class PromptManager {
         table.style.display = 'none';
 
         grid.innerHTML = this.prompts.map(prompt => this.createPromptCard(prompt)).join('');
+        grid.querySelectorAll('.prompt-card').forEach(card => {
+            card.addEventListener('click', () => {
+                grid.querySelectorAll('.prompt-card').forEach(c => c.classList.remove('selected'));
+                card.classList.add('selected');
+            });
+        });
     }
 
     renderTable() {
@@ -283,8 +289,7 @@ class PromptManager {
                 </div>
                 <div class="prompt-card-body">
                     <div class="prompt-meta">
-                        <span>📁 ${categoryPath}</span>
-                        <span>📅 ${createdDate}</span>
+                        ${this.categoryIcon(prompt.category)} ${categoryPath} - ${createdDate}
                     </div>
                     <div class="prompt-description">${prompt.shortDescription || 'Keine Kurzbeschreibung'}</div>
                     <div class="prompt-tags">
@@ -318,6 +323,11 @@ class PromptManager {
                 </td>
             </tr>
         `;
+    }
+
+    categoryIcon(categoryId) {
+        const cat = categoryManager.categories.find(c => c.id === categoryId);
+        return cat && !cat.parent ? '📁' : '';
     }
 
     showFullDescription(promptId) {

--- a/category-manager.js
+++ b/category-manager.js
@@ -92,8 +92,8 @@ class CategoryManager {
                 : '';
 
             return `
-                <div class="category-item category-level-${level}" data-category-id="${cat.id}">
-                    <div class="category-header">${toggleBtn}<span class="category-name" style="color: ${cat.color}">${cat.name} (${promptCount})</span></div>
+                <div class="category-item category-level-${level}" data-category-id="${cat.id}" style="--cat-color: ${cat.color}">
+                    <div class="category-header">${toggleBtn}<span class="category-name">${cat.name} (${promptCount})</span></div>
                     ${subcats}
                 </div>
             `;

--- a/styles.css
+++ b/styles.css
@@ -10,8 +10,8 @@
   --border-color: #d1d9e6;
   --text-primary: #1c1c1e;
   --text-secondary: #3a3a3c;
-  --shadow: 8px 8px 16px #b8c6db, -8px -8px 16px #ffffff;
-  --shadow-lg: 12px 12px 24px #b8c6db, -12px -12px 24px #ffffff;
+  --shadow: 8px 8px 16px #b8c6db, -8px -8px 16px #f0f0f3;
+  --shadow-lg: 12px 12px 24px #b8c6db, -12px -12px 24px #f0f0f3;
   --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }
 
@@ -178,6 +178,27 @@ button:hover {
   border-radius: 6px;
   cursor: pointer;
   transition: background 0.2s ease;
+  --cat-color: var(--primary-color);
+}
+
+.category-name {
+  color: var(--text-primary);
+  transition: color 0.2s ease;
+}
+
+.category-item:hover .category-name,
+.category-item.active .category-name {
+  color: var(--cat-color);
+}
+
+.category-item.active .category-name::before {
+  content: '';
+  display: inline-block;
+  width: 4px;
+  height: 1em;
+  background: var(--cat-color);
+  margin-right: 6px;
+  vertical-align: middle;
 }
 
 .category-header {
@@ -216,7 +237,6 @@ button:hover {
 
 .category-item.active {
   background: rgba(74, 144, 226, 0.1);
-  color: var(--primary-color);
 }
 
 .category-level-1 {
@@ -250,6 +270,10 @@ button:hover {
 .prompt-card:hover {
   transform: translateY(-2px);
   box-shadow: var(--shadow-lg);
+}
+
+.prompt-card.selected {
+  background: rgba(74, 144, 226, 0.1);
 }
 
 .prompt-card-header {
@@ -507,6 +531,7 @@ dialog::backdrop {
   margin: 4px 0;
   border-radius: 6px;
   background: var(--background-color);
+  box-shadow: none;
 }
 
 .category-edit-item input[type="text"] {


### PR DESCRIPTION
## Summary
- tone down white glow around cards and buttons
- color category links only on hover/selection and add a vertical bar when active
- highlight selected prompt card
- remove calendar icon from cards and show folder icon only for top level categories
- remove glow from category management tiles

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68529328acd8832eb3294d2088261517